### PR TITLE
Fix typos and add color to back link

### DIFF
--- a/content/nettest/http-host.md
+++ b/content/nettest/http-host.md
@@ -1,6 +1,6 @@
 ---
 title: "HTTP Host"
-short_description: "This test examine whether the domain names of websites are blocked."
+short_description: "This test examines whether the domain names of websites are blocked."
 groups: ["website"]
 date: "0002-01-01"
 ---

--- a/content/nettest/meek-fronted-requests.md
+++ b/content/nettest/meek-fronted-requests.md
@@ -3,6 +3,7 @@ title: "Meek Fronted Requests"
 short_description: "This test examines whether the domains used by Meek (a type of Tor
 bridge) work in tested networks."
 groups: ["tor"]
+date: "0002-01-01"
 ---
 
 # Meek Fronted Requests

--- a/content/nettest/tor-bridge-reachability.md
+++ b/content/nettest/tor-bridge-reachability.md
@@ -3,6 +3,7 @@ title: "Tor Bridge Reachability"
 short_description: "This test examines whether Tor bridges
 work in tested networks."
 groups: ["tor"]
+date: "0001-01-01"
 ---
 
 # Tor Bridge Reachability

--- a/content/nettest/vanilla-tor.md
+++ b/content/nettest/vanilla-tor.md
@@ -3,6 +3,7 @@ title: "Vanilla Tor"
 short_description: "This test examines the reachability of the Tor network (which is designed for online anonymity
 and censorship circumvention)."
 groups: ["tor"]
+date: "0000-01-01"
 ---
 
 # Vanilla Tor

--- a/themes/ooni/layouts/section/nettest.html
+++ b/themes/ooni/layouts/section/nettest.html
@@ -17,18 +17,18 @@
 
   <main class="col-3">
     <p class="test-intro">
-        Interested in running OONI's software tests to collect evidence of internet censorship? Below we include descriptions for all of OONI's tests. For more detailed descriptions, click below on the tests of your choice!
+        Interested in running OONI's software tests to collect evidence of internet censorship? Below we explain what each OONI test is designed to do. Click on the tests below to learn more!
     </p>
 
     <ul class="test-overivew">
-      <a href="#websites"><li>Which websites are blocked?</li></a>
-      <a href="#im"><li>Which Instant Messaging Apps are blocked?</li></a>
-      <a href="#boxes"><li>Which censorship technologies are in my network?</li></a>
-      <a href="#tor"><li>Is Tor blocked?</li></a>
-      <a href="#proxies"><li>Are proxies blocked?</li></a>
+      <a href="#websites" class="test-link"><li>Which websites are blocked?</li></a>
+      <a href="#im" class="test-link"><li>Which Instant Messaging Apps are blocked?</li></a>
+      <a href="#boxes" class="test-link"><li>Which censorship technologies are in my network?</li></a>
+      <a href="#tor" class="test-link"><li>Is Tor blocked?</li></a>
+      <a href="#proxies" class="test-link"><li>Are proxies blocked?</li></a>
     </ul>
 
-    <h1 id="websites" class="test-header">Wich websites are blocked?</h1>
+    <h1 id="websites" class="test-header">Which websites are blocked?</h1>
     <div class="row question-container">
       {{ range .Data.Pages.ByDate }}
         {{ if in .Params.groups "website" }}
@@ -75,7 +75,7 @@
 
     <h1 id="tor" class="test-header">Is Tor blocked?</h1>
     <div class="row question-container">
-      {{ range .Data.Pages }}
+      {{ range .Data.Pages.ByDate }}
         {{ if in .Params.groups "tor" }}
           {{ $TITLE := title (replace (index (split .RelPermalink "/") 2) "-" " ") }}
           <a href="{{ .RelPermalink }}" class="col-3">

--- a/themes/ooni/static/css/master.css
+++ b/themes/ooni/static/css/master.css
@@ -812,3 +812,7 @@ p.test-paragraph {
   cursor: pointer;
   transition: .1s;
 }
+
+.toc a {
+  color: #0588cb;
+}


### PR DESCRIPTION
I forgot to merge the latest changes in this PR (https://github.com/TheTorProject/ooni-web/pull/87)

- Color the back link blue
- Ordering of the tests in the "Tor" section
- Underline links while hovering