### PR TITLE
bootstrap fixes for mobile views

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,10 +14,10 @@
 
     <header>
       <div class="row">
-      <div class="col-3 mt-5">
-        <img class="logo" src="/images/ooni-header-mascot.png" srcset="/images/ooni-header-mascot-2x.png 2x" height="200" width="200"/>
+      <div class="col-12 col-md-4 col-lg-3 mt-5 ml-auto mr-auto">
+        <img class="logo d-block m-auto" src="/images/ooni-header-mascot.png" srcset="/images/ooni-header-mascot-2x.png 2x" height="200" width="200"/>
       </div>
-        <div class="col-9 mb-5 mt-5">
+        <div class="col-12 col-md-8 col-lg-9 mb-5 mt-5">
           <img class="wordmark" src="/images/wordmark.png" srcset="/images/wordmark-2x.png 2x" alt="OONI"/>
           <h2>Open Observatory of Network Interference</h2>
           <p>A free software, global observation network for detecting censorship,
@@ -31,13 +31,13 @@
       <div class="ooni-explorer">
       <div class="container">
         <div class="row">
-          <div class="col-3">
+          <div class="col-12 col-md-4 col-lg-3">
             <h2 class="overlined">OONI Explorer</h2>
               <p class="subtext">OONI has been monitoring internet censorship around the world since 2012</p>
               <p class="subtext"><a class="explorer-button btn" href="https://explorer.ooni.org/">Explore OONI Data</a></p>
           </div>
 
-        <div class="col-9">
+        <div class="col-12 col-md-8 col-lg-9">
         <img src="/images/ooni-explorer-screenshot" srcset="/images/ooni-explorer-screenshot@2x.png 1440w"  />
       </div>
     </div>
@@ -72,7 +72,7 @@
     <div class="how-it-works">
       <div class="container">
         <div class="row">
-          <div class="col-3">
+          <div class="col-12 col-md-4 col-lg-3">
             <h2 class="overlined">How OONI Works</h2>
             <p class="subtext">OONI scans TCP, DNS, HTTP and TLS connections for tampering. Some tests
             work by requesting data over an unencrypted connection and comparing
@@ -80,8 +80,8 @@
             filtering, transparent proxying and website block lists.</p>
             <p class="cta"><a style="color: white;" href="/support/glossary">Read the OONI glossary</a></p>
           </div>
-          <div class="col-9">
-            <img src="/images/how-ooni-works.png" srcset="/images/how-ooni-works-2x.png 2x" width="680" height="280" />
+          <div class="col-12 col-md-8 col-lg-9">
+            <img src="/images/how-ooni-works.png" srcset="/images/how-ooni-works-2x.png 2x"/>
           </div>
         </div>
       </div>

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -176,10 +176,11 @@ p.cta a::after {
   content: " →";
 }
 
+@media screen and (max-width:576px) {
 .subtext {
   margin-top:20%
 }
-
+}
 /* ================================================================== */
 /* Block quotes */
 
@@ -401,6 +402,7 @@ header .wordmark {
   display: block;
   object-fit: contain;
   height: 17.5rem;
+  width: 100%;
 }
 
 .homepage .ooni-explorer img {


### PR DESCRIPTION
The mobile views are currently broken, here are some fixes for the homepage (the sponsors could still use some love but this is all I got time for right now).
Generally the best way to work with bootstrap I've found is to go from the smallest device upwards - considering the largest view, bootstrap will automatically fall back to the next smaller one if none is defined, all the way down to the smallest one, if there are no definitions in between. 
So I usually start with the smallest, work my way upwards and only set other definitions when the (next) smallest one doesn't work on larger devices. Hope that makes any sense. Here's more info: https://getbootstrap.com/docs/4.0/layout/grid/
