### PR TITLE
bootstrap adjustments for /data on mobile

### DIFF
--- a/layouts/section/data.html
+++ b/layouts/section/data.html
@@ -2,9 +2,9 @@
 <div class="container">
   <main class="col pt-5 pb-5">
     <div class="row justify-content-around pt-5">
-      <div class="col-4">
+      <div class="col-12 col-sm-4">
         <a href="https://explorer.ooni.io">
-        <img src="/data/ooni-explorer.png" id="ooni-explorer" />
+        <img src="/data/ooni-explorer.png" class="xs-center" id="ooni-explorer" />
         </a>
         <p style="padding-top: 30px">
         <a href="https://explorer.ooni.io/">OONI Explorer</a>
@@ -13,8 +13,8 @@
         through OONI tests from 2012 until today.
         </p>
       </div>
-      <div class="col-4">
-        <a href="https://api.ooni.io"><img src="/data/ooni-api.png" id="ooni-api"/></a>
+      <div class="col-12 col-sm-4">
+        <a href="https://api.ooni.io"><img class="xs-center" src="/data/ooni-api.png" id="ooni-api"/></a>
         <p style="padding-top: 30px">
         We offer a measurement API that allows researchers to perform their own analysis of OONI data.
         You can read more about our data format inside of <a

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -177,9 +177,14 @@ p.cta a::after {
 }
 
 @media screen and (max-width:576px) {
-.subtext {
-  margin-top:20%
-}
+  .subtext {
+    margin-top:20%
+  }
+  .xs-center {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 /* ================================================================== */
 /* Block quotes */


### PR DESCRIPTION
Adjustments for mobile views.

Added a helper class `.xs-center` for centering things on mobile (< 576px). (mostly to replace `class="d-block ml-auto mr-auto"` definitions, which are a bit verbose and can also interact in other views)
