### PR TITLE
revert edits to nav bar which leads them to overflow on mobile

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -56,13 +56,13 @@
 
   {{ $selectedMenu := split .URL "/" }}
   <nav class="container">
-    <div class="col-12 col-md-4">
+    <div class="col-3">
       <a href="/">
         <img class="logo" src="/images/ooni-header-mascot.png" width="25" height="25"/>
         <img class="wordmark" src="/images/wordmark.png" alt="OONI" height="14" width="53"/>
       </a>
     </div>
-    <div class="col-12 col-md-8">
+    <div class="col-9">
       <div class="nav-menu">
       <a href="/about/"
         {{ if in $selectedMenu "about" }}


### PR DESCRIPTION
I made an erroneous change to the nav bar which currently makes it overflow to the right on mobile views, this should fix it again. Apologies for this