### PR TITLE
Fixup links to github and other related pages

### DIFF
--- a/content/about/risks.md
+++ b/content/about/risks.md
@@ -28,7 +28,7 @@ Therefore the potential risks associated to running OONI Probe depend on:
 
 ## Understanding potential risks more comprehensively
 
-OONI's [software tests](https://github.com/TheTorProject/ooni-probe) (called
+OONI's [software tests](https://github.com/ooni/probe) (called
 OONI Probe) are designed to test networks for signs of censorship, surveillance
 and traffic manipulation. In some countries around the world using OONI Probe may
 result in criminal prosecution, fines, or even imprisonment. We therefore
@@ -38,7 +38,7 @@ the documentation below.
 
 Users run OONI Probe at their own risk. By installing OONI Probe, users agree to
 comply with OONI's software
-[license](https://github.com/TheTorProject/ooni-probe/blob/master/LICENSE)
+[license](https://github.com/ooni/license)
 and [Data Policy](/about/data-policy). Neither the
 [OONI project](https://ooni.org/) nor its parent organization, [The Tor Project](https://www.torproject.org/), can be held liable, jointly or
 severally, at law or at equity, to OONI Probe users and other third parties, for
@@ -176,7 +176,7 @@ bridges](https://bridges.torproject.org/), [Psiphon](https://psiphon.ca/) and
 [Lantern](https://getlantern.org/), are blocked.
 
 We urge you to review the
-**[specifications](https://github.com/TheTorProject/ooni-spec/tree/master/test-specs)**
+**[specifications](https://github.com/ooni/spec)**
 for each OONI Probe test carefully, prior to running them.
 
 #### Legality of tested websites
@@ -301,7 +301,7 @@ Please confirm you are reading the latest version before relying on any advice.
 
 Again, users run OONI Probe at their own risk. By installing OONI Probe, users agree to
 comply with OONI's software
-[license](https://github.com/TheTorProject/ooni-probe/blob/master/LICENSE)
+[license](https://github.com/ooni/license)
 and [Data Policy](/about/data-policy). Neither the
 [OONI project](https://ooni.org/) nor its parent organization, [The Tor Project](https://www.torproject.org/), can be held liable, jointly or
 severally, at law or at equity, to OONI Probe users and other third parties, for

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -24,10 +24,6 @@
 {{ end }}
 {{ define "main" }}
 <div class="homepage">
-
- <a href="https://github.com/ooni">
-   <img class="fork-me" style="position: absolute; top: 0; left: 0; border: 0;" src="/images/forkme_left_gray_6d6d6d.png" alt="Fork me on GitHub"/>
- </a>
  <div class="container">
     <header>
       <div class="row">
@@ -144,19 +140,15 @@
           <h2 class="overlined">Getting Involved</h2>
         </div>
         <div class="col-9">
-            <p>Join us in IRC <a href="ircs://irc.oftc.net:6697/#ooni">#ooni on OFTC</a> (or via a <a href="https://slack.openobservatory.org/">slack bridge</a>)
-            or on the
-            <a href="https://lists.torproject.org/cgi-bin/mailman/listinfo/ooni-talk">ooni-talk</a> and 
-            <a href="https://lists.torproject.org/cgi-bin/mailman/listinfo/ooni-dev">ooni-dev</a> mailing lists
-            to discuss the project, what you've learned from measurements and ways
-            you can help out.
+            <p>Join on the <a href="https://slack.ooni.org/">OONI public slack channel</a> (some channels are also bridged with IRC <a href="ircs://irc.oftc.net:6697/#ooni">#ooni, #ooni-dev, #ooni-entropy on OFTC</a>)
+            or on the <a
+              href="https://lists.torproject.org/cgi-bin/mailman/listinfo/ooni-talk">ooni-talk</a>
+            mailing lists to discuss the project, what you've learned from
+            measurements and ways you can help out.
           </p>
-          <p>If you are contributing regular ooniprobe measurements be sure to also subscribe to
-          <a href="https://lists.torproject.org/cgi-bin/mailman/listinfo/ooni-operators">ooni-operators</a> for important updates.
-          </p>
-          <p><a href="https://github.com/TheTorProject/ooni-probe">Source code</a>
-            is available (<a href="https://gitweb.torproject.org/ooni-probe.git">Tor project mirror</a>).
-            Issues and future plans for OONI can be <a href="https://github.com/thetorproject/ooni-probe/issues">found on github</a>.</p>
+          <p><a href="https://github.com/ooni/">Source code</a>
+            is available.
+            Issues and future plans for OONI can be <a href="https://github.com/ooni/ooni.org/issues">found on github</a>.</p>
         </div>
       </div>
 
@@ -170,9 +162,6 @@
             <p class="fingerprint">
             Key ID: 6B2943F00CB177B7<br>
             Fingerprint: 4C15 DDA9 96C6 C0CF 48BD 3309 6B29 43F0 0CB1 77B7
-            </p>
-            <p>
-            We can also be reached <a href="/about/#contact">on Jabber</a>.
             </p>
         </div>
       </div>

--- a/layouts/section/about.html
+++ b/layouts/section/about.html
@@ -8,7 +8,7 @@
     is a <i>free software</i> project under <a href="https://torproject.org">The Tor Project</a>
     which aims to empower decentralized efforts in increasing transparency of internet censorship around the world.</p>
 
-    <p>We develop <a href="https://github.com/TheTorProject/ooni-probe">free and open source software</a>, called <strong>OONI Probe</strong>, that you can run to measure: 
+    <p>We develop <a href="https://github.com/ooni/probe">free and open source software</a>, called <strong>OONI Probe</strong>, that you can run to measure:
     <ul>
       <li>Blocking of websites;</li>
       <li>Blocking of instant messaging apps (WhatsApp, Facebook Messenger and Telegram);</li>

--- a/layouts/section/data.html
+++ b/layouts/section/data.html
@@ -18,7 +18,7 @@
         <p style="padding-top: 30px">
         We offer a measurement API that allows researchers to perform their own analysis of OONI data.
         You can read more about our data format inside of <a
-          href="https://github.com/TheTorProject/ooni-spec">ooni-spec</a>
+          href="https://github.com/ooni/spec">OONI Spec</a>
         and access the
         <a
           href="https://api.ooni.io/">OONI API

--- a/layouts/section/get-involved.html
+++ b/layouts/section/get-involved.html
@@ -39,14 +39,9 @@
         <p>
         Our source code is available on
         <a href="https://github.com/ooni">GitHub</a>
-        and mirrored on
-        <a href="https://gitweb.torproject.org/ooni-probe.git">Tor Project git</a>.
         If you have code you would like to contribute, please <a
-          href="https://github.com/TheTorProject/ooni-probe/compare">open a pull request</a> or <a href="https://github.com/TheTorProject/ooni-probe/issues/new">file an issue</a>.
+          href="https://github.com/ooni">open a pull request</a> or <a href="https://github.com/ooni/ooni.org/issues/new">file an issue</a>.
         </p>
-        <p>If you are interested in hacking on OONI or writing your own
-        nettests, please refer to our <a href="/docs/">developer
-        documentation</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Replaces links to github.com/thetorproject with github.com/ooni.