### PR TITLE
testing collapsible tables for mobile views

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,6 +24,7 @@
 
   <link rel="stylesheet" href="{{ $bootstrap.Permalink }}">
   <link rel="stylesheet" href="/css/master.css"/>
+  <link rel="stylesheet" type="text/css" href="/css/collapse-tables.css">
 
   {{/* Deferred loading of css based on: https://web.dev/defer-non-critical-css/ */}}
   <link rel="preload" href="/css/highlight-default.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
@@ -32,6 +33,7 @@
   <link rel="icon" type="image/png" href="/images/favicon.png"/>
   <script src="/js/highlight.min.js" defer></script>
   <script src="/js/zepto.min.js" defer></script>
+  <script type="text/javascript" src="/js/collapse-tables.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/ooni-run/dist/widgets.js" defer></script>
   <script defer>hljs.initHighlightingOnLoad();</script>
 	<!-- Piwik -->

--- a/static/css/collapse-tables.css
+++ b/static/css/collapse-tables.css
@@ -1,0 +1,61 @@
+@media screen and (max-width: 576px) {
+    table.js-collapse {
+        border-collapse: collapse;
+        margin: 0;
+        padding: 0;
+        display: block;
+        width: 100%;
+        table-layout: fixed;
+        overflow-x: unset;
+    }
+
+    table.js-collapse tbody {
+        display: block;
+        width:100%;
+    }
+
+    table.js-collapse caption {
+        font-size: 1.3em;
+    }
+
+    table.js-collapse thead {
+        border: none;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+    }
+
+    table.js-collapse tr {
+        border-bottom: 3px solid #ddd;
+        display: block;
+        margin-bottom: .625em;
+    }
+
+    table.js-collapse td {
+        border-bottom: 1px solid #ddd;
+        display: block;
+        font-size: .8em;
+        text-align: right;
+        background: #FFF !important;
+        min-height: 40px;
+    }
+
+    table.js-collapse td:nth-child(odd) {
+        background: #E9ECEF !important;
+    }
+
+    table.js-collapse td::before {
+        content: attr(data-label);
+        float: left;
+        font-weight: bold;
+        text-transform: uppercase;
+    }
+
+    table.js-collapse td:last-child {
+        border-bottom: 0;
+    }
+}

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -53,6 +53,17 @@ footer a:hover {
   text-decoration: none;
 }
 
+@media screen and (max-width:576px) {
+  .subtext {
+    margin-top:20%
+  }
+  .xs-center {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 /* ================================================================== */
 /* Rows */
 
@@ -176,16 +187,6 @@ p.cta a::after {
   content: " →";
 }
 
-@media screen and (max-width:576px) {
-  .subtext {
-    margin-top:20%
-  }
-  .xs-center {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-  }
-}
 /* ================================================================== */
 /* Block quotes */
 
@@ -233,6 +234,10 @@ table {
     background: white;
     border-radius: 3px;
     border-collapse: collapse;
+    overflow-x: auto;
+    display: block;
+    width: max-content;
+    max-width: 100%;
     padding: 5px;
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
     animation: float 5s infinite;
@@ -296,7 +301,7 @@ td {
   text-align: center;
   vertical-align: middle;
   font-weight: 300;
-  font-size: 18px;
+  font-size: 16px;
   text-shadow: -1px -1px 1px rgba(0, 0, 0, 0.1);
   border-right: 1px dashed #FFF;
 }

--- a/static/js/collapse-tables.js
+++ b/static/js/collapse-tables.js
@@ -1,0 +1,15 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const tables = Array.from(document.querySelectorAll("table"));
+    console.log(tables)
+    tables.forEach((table, i) => {
+        table.classList.add("js-collapse");
+        let labels = [];
+        table.querySelectorAll("thead th").forEach(function(header, i) {
+            labels.push(header.innerText);
+        });
+        console.log(labels)
+        table.querySelectorAll("table tbody tr td").forEach(function(cell, i) {
+            cell.setAttribute("data-label", labels[cell.cellIndex]);
+        });
+    });
+});


### PR DESCRIPTION
This is meant as a test branch for collapsible (column to rows) tables for mobile views, it works through a Javascript that adds table header captions as attributes into corresponding `<td>` tags which are then prepended using CSS. When Javascript is disabled it falls back to scrollbars where tables overflow.

Things to consider:
- This currently applies to all `<table>` tags. If this is not intended it would be required to add an identifier class to the tables this should apply to and adjust the topmost querySelector in the script to it.
- Occasionally `<td>`'s seem to be used for annotation, e.g. `This site is likely blocked because it can also be used as a censorship circumvention tool by acting as a web proxy.` at https://ooni.org/post/indonesia-internet-censorship/ , this would be wrongly displayed as its own table using the current approach (but could be circumvented by giving those `<td>`'s a special class)
- The CSS markup for the collapsed tables might require some tweaking to fit into the overall design
