### PR TITLE
Update the get-involved/run URLs

### DIFF
--- a/content/get-involved/run.md
+++ b/content/get-involved/run.md
@@ -131,7 +131,7 @@ https://ultrasurf.us/
 http://anonymouse.org/
 {{</oonirunurls>}}
 
-{{<oonirunurls text="Wikipedia (24 URLs)">}}
+{{<oonirunurls text="Wikipedia (25 URLs)">}}
 https://www.wikipedia.org/
 https://en.wikipedia.org/
 https://en.m.wikipedia.org/
@@ -156,6 +156,7 @@ https://it.m.wikipedia.org/
 https://commons.wikimedia.org/
 https://wikidata.org/
 https://upload.wikimedia.org/
+https://fa.wikipedia.org/
 {{</oonirunurls>}}
 
 {{<oonirunurls text="Human Rights (27 URLs)">}}


### PR DESCRIPTION
Add fa.wikipedia.org to the URL list