### PR TITLE
Statement in support of OTF

### DIFF
--- a/content/post/2020-support-otf/index.md
+++ b/content/post/2020-support-otf/index.md
@@ -218,7 +218,7 @@ petition in Pakistan](http://digitalrightsmonitor.pk/islamabad-high-court-takes-
 which challenged the [blocking of media websites and popular social
 media
 platforms](https://ooni.org/post/how-pakistan-blocked-social-media/)
-during the 2017 November protests. As an outcome, the Islamabad High
+during the November 2017 protests. As an outcome, the Islamabad High
 Court
 [declared](https://tribune.com.pk/story/2061933/1-pta-not-empowered-block-website-ihc)
 that the Pakistan Telecommunications Authority cannot regulate content

--- a/content/post/2020-support-otf/index.md
+++ b/content/post/2020-support-otf/index.md
@@ -1,0 +1,262 @@
+---
+categories:
+  - blog
+title: "Support the OTF: Support a Free and Open Internet"
+description: OONI statement in support of the OTF.
+date: 2020-07-22
+author: Maria Xynou
+tags:
+  - otf
+  - saveinternetfreedom
+  - statement
+thumbnail: /images/uploads/cover-logo-save-otf.png
+---
+
+Over the last month, the [Open Technology Fund (OTF)](https://www.opentech.fund/) -- *one of the main funders of free
+censorship circumvention and privacy-enhancing technologies that human
+rights defenders worldwide rely on* -- has been under threat, following
+the [ousting of its leadership](https://edition.cnn.com/2020/06/17/media/us-agency-for-global-media-michael-pack/index.html).
+
+We previously published a [statement in support of the OTF](https://ooni.org/post/2020-06-19-save-internet-freedom-support-the-open-technology-fund/),
+explaining **why we think the OTF is essential for internet freedom**
+and encouraging the public to [sign the letter to congress](https://saveinternetfreedom.tech/).
+
+In this post, we share our experience working with the OTF, and discuss
+how they have played a crucial role in supporting the fight against
+internet censorship worldwide.
+
+* [Creating the first free and open source tools for measuring internet censorship](#creating-the-first-free-and-open-source-tools-for-measuring-internet-censorship)
+
+* [Supporting innovative projects requires expertise](#supporting-innovative-projects-requires-expertise)
+
+* [Supporting a global community fighting internet censorship](#supporting-a-global-community-fighting-internet-censorship)
+
+* [Trust in leadership](#trust-in-leadership)
+
+# Creating the first free and open source tools for measuring internet censorship
+
+We first [received OTF support](https://www.opentech.fund/results/supported-projects/ooni-open-observatory-of-network-interference/)
+back in 2012, when free and open source software for measuring internet
+censorship didn’t really exist.
+
+While there were great projects measuring internet censorship at the
+time (such as the [OpenNet Initiative](https://opennet.net/), which
+has inspired our work in many ways), there wasn’t really a free tool
+available that anyone around the world could run to independently
+measure internet censorship. Moreover, the measurements collected as
+part of censorship measurement experiments weren’t always openly
+published, limiting transparency of internet censorship and making it
+hard to verify censorship claims and research findings.
+
+We therefore sought to create the **first open framework for measuring
+internet censorship** and other forms of network interference around the
+world. In practice, this meant:
+
+* Creating **[open methodologies](https://ooni.org/nettest/)** for
+measuring internet censorship;
+
+* Designing and developing **[free and open source software tests](https://github.com/ooni)** for measuring various forms of
+internet censorship;
+
+* Developing **[mobile and desktop apps](https://ooni.org/install/)** to enable the public to easily
+run censorship measurement tests;
+
+* Setting up infrastructure to automatically collect censorship
+measurement results from around the world;
+
+* Designing and developing a [data processing pipeline](https://github.com/ooni/pipeline) to analyze and make
+sense of the measurements collected worldwide;
+
+* Building a platform to **[openly publish censorship measurements](https://api.ooni.io/)** from around the world (and
+enable third parties to download the raw data);
+
+* Creating a **[web platform and search tool](https://explorer.ooni.org/)** to enable access and use of
+censorship measurements.
+
+By creating open methodologies, building free and open source software,
+and openly publishing all network measurements collected from around the
+world, our goal was to **increase transparency of internet censorship
+worldwide** (thereby supporting policy and advocacy efforts, and the
+development and deployment of circumvention tools), enable the
+**independent, third-party verification** of our findings, support
+**reproducible research**, and to encourage researchers and developers
+worldwide to help us improve our methods.
+
+Thanks to [OTF support](https://www.opentech.fund/results/supported-projects/ooni-open-observatory-of-network-interference/)
+over the years, we have managed to achieve this goal.
+
+Today, our censorship measurement apps -- called [OONI Probe](https://ooni.org/install/) -- are run by hundreds of thousands
+of users in [more than 200 countries every month](https://explorer.ooni.org/). In fact, a large volume of tests are run in
+countries with pervasive levels of internet censorship, such as
+[Russia](https://explorer.ooni.org/country/RU) and
+[Iran](https://explorer.ooni.org/country/IR) (and many tests are
+regularly run in countries like
+[China](https://explorer.ooni.org/country/CN) as well). As soon as
+OONI Probe tests are run anywhere around the world, the test results are
+(automatically) **openly published in near real-time**. 
+
+[OONI Explorer](https://explorer.ooni.org/) and the [OONI
+API](https://api.ooni.io/) not only serve as the **largest open
+datasets of internet censorship to date**, but they also enable human
+rights defenders to track global censorship events as they emerge.
+
+# Supporting innovative projects requires expertise
+
+Realistically, very few funders would have supported a project like OONI
+back in 2012. Funding software development is often thought of as a
+risky investment, and even more so when it’s carried out by an
+organization that hasn’t received funding support before, or which is
+not well-known within funder circles. Ultimately, this means that
+passionate and talented researchers, developers, and human rights
+defenders who could potentially play a pivotal role in defending
+internet freedom don’t receive support, limiting the impact of their
+work.
+
+This is why the OTF is so crucial for the internet freedom community.
+
+Rather than mainly supporting established organizations, the OTF sought
+to identify passionate activists and developers from across the globe
+and help bring their innovative ideas to life.
+
+No idea is “too innovative” or “too risky” to support, as long as it’s
+realistically feasible. To evaluate whether an idea is realistically
+feasible, you need to have in-house experts.
+
+**Because the OTF had internet freedom experts in its
+[team](https://www.opentech.fund/about/people/?person_type=1),
+leadership, and [Advisory Council](https://www.opentech.fund/about/people/?person_type=5), it was
+able to successfully support a number of innovative projects over the
+last 8 years that advanced internet freedom worldwide.**
+
+From our own personal experience (having submitted multiple proposals to
+the OTF over the years), this has meant that when we submitted a funding
+proposal, it was evaluated by the OTF’s highly specialized team and
+Advisory Council, both of whom share lots of feedback.
+
+Through these rounds of feedback, their goal has always been to ensure
+that the proposed project:
+
+* is relevant and supports the needs of the internet freedom
+community;
+
+* is as competitive as it can be;
+
+* is realistically feasible;
+
+* can be practically implemented based on a specified and reasonable
+plan;
+
+* acknowledges existing efforts and advances the field.
+
+Because the OTF’s team and Advisory Council consist of internet freedom
+experts from around the world (including repressive environments), they
+are well-positioned to understand community needs and how projects can
+support them. **They are also extremely well-positioned to help
+innovative projects actually succeed once they have received support.**
+
+Over the years, the OTF team has helped us grow OONI by offering
+continuous guidance, advice and support, often challenging us and
+encouraging us to prioritize community needs. This was possible because
+the OTF was led by internet freedom defenders and experts.
+
+# Supporting a global community fighting internet censorship
+
+Creating free and open source software to fight internet censorship is
+important, but not enough.
+
+We need people to run this software, and we need people to engage others
+with censorship measurement. We need people to discuss why measuring
+internet censorship is important to begin with. 
+
+We need human rights defenders to inform their advocacy and policy efforts with censorship
+measurement data. We need lawyers to challenge illegal censorship events
+in courts with censorship measurement data that can serve as evidence.
+
+We need journalists to encourage public
+debate on hidden cases of internet censorship. We need researchers and
+developers to improve censorship circumvention techniques and
+technologies -- which can be enabled with more knowledge of how internet censorship is implemented worldwide.
+
+Because the OTF understands the value of a global community in defending
+internet freedom, they not only fund tools and research -- **they fund
+the entire internet freedom ecosystem**.
+
+In the context of our work, this has meant support for the establishment
+and development of the [OONI Partnership Program](https://ooni.org/get-involved/partnership-program/), a global
+coalition of human rights organizations collaborating on increasing
+transparency of internet censorship through [OONI Probe](https://ooni.org/install/) censorship measurement.
+
+These partnerships have contributed to the expansion of the breadth and
+granularity of global coverage of censorship events, as our partners
+have contributed stable measurements and engaged their local communities
+with censorship measurement research and advocacy.
+
+Collaboration with talented technologists around the world has also
+resulted in the expansion and improvement of our censorship measurement
+methodologies, particularly when such collaboration involved [running experiments in countries like Iran](https://ooni.org/post/2020-iran-dot/), which experience
+sophisticated and pervasive levels of internet censorship.
+
+A few years ago, the OTF also supported the [OONI Partner Gathering](https://ooni.org/post/ooni-partner-gathering-2017/), a
+two-day event which brought all of our partners together to share skills
+and knowledge around censorship measurement research. This event enabled
+us to gain a deeper understanding of [community needs](https://ooni.org/post/ooni-partner-gathering-2017/#challenges-and-needs)
+and to involve our partners in [shaping our software development priorities](https://ooni.org/post/ooni-partner-gathering-2017/#future-goals-and-priorities)
+based on their needs.
+
+Thanks to OTF support, we have collaborated with human rights
+organizations in more than 27 countries in Asia, the Middle East,
+Africa, East Europe, and Latin America. These partnerships have resulted
+in the improvement of [censorship measurement resources](https://github.com/citizenlab/test-lists) and in the
+[publication of multiple research reports](https://ooni.org/reports/),
+sharing data on censorship events worldwide.
+
+These research reports have supported the advocacy efforts of Access
+Now’s [KeepItOn campaign](https://www.accessnow.org/keepiton/), a
+global coalition of human rights organizations fighting internet
+shutdowns around the world. Recently, OONI data supported a [High Court
+petition in Pakistan](http://digitalrightsmonitor.pk/islamabad-high-court-takes-up-petition-filed-by-rights-activists-challenging-the-legality-of-social-media-takedown-during-faizabad-dharna-issues-notices-to-pta-and-the-federal-government/),
+which challenged the [blocking of media websites and popular social
+media
+platforms](https://ooni.org/post/how-pakistan-blocked-social-media/)
+during the 2017 November protests. As an outcome, the Islamabad High
+Court
+[declared](https://tribune.com.pk/story/2061933/1-pta-not-empowered-block-website-ihc)
+that the Pakistan Telecommunications Authority cannot regulate content
+without following the due process, the principles of transparency, and
+oversight.
+
+To increase the sustainability of our work, the OTF has not only
+supported the expansion of the OONI-verse by supporting our
+community work, but they have also supported many of our partners
+directly, who have built their own [regional censorship dashboards](https://censorship.sinarproject.org/) and published
+[independent research](https://medium.com/@cyberlabukraine) (through
+the use of OONI Probe and OONI data).
+
+To aid the global fight against internet censorship, the OTF has
+supported global and local communities around the world. And this is
+precisely why the internet freedom community trusts the OTF.
+
+# Trust in leadership
+
+**It is essential that OTF leadership continues to consist of
+individuals who are part of and trusted by the internet freedom
+community.**
+
+Over the last years, the OTF has received funding proposals from
+marginalized communities in repressive environments *because there has
+been trust towards the organization’s leadership*.
+
+**If OTF were to lose that trust, it would likely also lose applications
+from individuals who are best-positioned to combat internet censorship
+and defend internet freedom.**
+
+If future OTF leadership is not already part of the internet freedom
+community, they will likely *not* have the insight and expertise
+necessary for determining which projects deserve support in order to
+best serve community needs and defend internet freedom.
+
+We therefore request that OTF leadership continues to consist of
+individuals trusted by the internet freedom community.
+
+We encourage you to join us in [signing this letter to congress](https://saveinternetfreedom.tech/) in support of the OTF, in
+support of internet freedom as we know it.

--- a/content/post/2020-support-otf/index.md
+++ b/content/post/2020-support-otf/index.md
@@ -97,7 +97,7 @@ OONI Probe tests are run anywhere around the world, the test results are
 
 [OONI Explorer](https://explorer.ooni.org/) and the [OONI
 API](https://api.ooni.io/) not only serve as the **largest open
-datasets of internet censorship to date**, but they also enable human
+datasets on internet censorship to date**, but they also enable human
 rights defenders to track global censorship events as they emerge.
 
 # Supporting innovative projects requires expertise


### PR DESCRIPTION
This is a follow-up post (after this: https://ooni.org/post/2020-06-19-save-internet-freedom-support-the-open-technology-fund/) in support of the OTF.