### PR TITLE
Bump probe-desktop download version to 3.0.3

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ pluralizeListTitles = false
 
 [params]
 description = "The Open Observatory of Network Interference (OONI) is a global community measuring internet censorship around the world. Run OONI Probe to detect internet censorship. Use OONI Explorer to track internet censorship worldwide in near real-time."
-probeDesktopVersion = "3.0.2"
+probeDesktopVersion = "3.0.3"
 
 [Languages]
 [Languages.ar]


### PR DESCRIPTION
We missed doing this for the last release. I have now added this step to the [release checklist document](https://docs.google.com/document/d/144_th31QJnwxpWXMFkMzKYwxdofUzZ64k8Thu_ulZqU/edit?skip_itp2_check=true&pli=1).