### PR TITLE
Bump probe-desktop download version to 3.0.4

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ pluralizeListTitles = false
 
 [params]
 description = "The Open Observatory of Network Interference (OONI) is a global community measuring internet censorship around the world. Run OONI Probe to detect internet censorship. Use OONI Explorer to track internet censorship worldwide in near real-time."
-probeDesktopVersion = "3.0.3"
+probeDesktopVersion = "3.0.4"
 
 [Languages]
 [Languages.ar]


### PR DESCRIPTION
Released [3.0.4](https://github.com/ooni/probe-desktop/releases/tag/v3.0.4)