### PR TITLE
add a RiseupVPN test description

### DIFF
--- a/content/nettest/riseupvpn.md
+++ b/content/nettest/riseupvpn.md
@@ -1,23 +1,21 @@
 ---
-title: "Riseupvpn"
+title: "RiseupVPN"
 short_description: "This test provides an automated way of examining whether RiseupVPN works in a
 tested network."
 groups: ["proxies"]
 ---
 
-# RiseupVPN
-
-This test provides an automated way of examining whether RiseupVPN works in a tested network.
-
+# RiseupVPN 
 
 ## About RiseupVPN
-[RiseupVPN](https://riseup.net/vpn) is a non-commercial, donation-based VPN service. It offers simple to use clients to secure your internet traffic against survaillance and to circumvent internet censorship. RiseupVPN doesn't log any user data and doesn't require registration.
-The software is based on [LEAP VPN](https://leap.se/), an open source VPN solution, and is run by the [Riseup collective](https://riseup.net/about-us) which offers privacy preserving online services for activists for more than 20 years. 
+[RiseupVPN](https://riseup.net/vpn) is a non-commercial, donation-based VPN service. It offers simple-to-use clients to secure your internet traffic against surveillance and to circumvent internet censorship. RiseupVPN doesn't log any user data and doesn't require registration. The software is based on [LEAP VPN](https://leap.se/), an open source VPN solution, and is run by the [Riseup collective](https://riseup.net/about-us) which has been offering privacy-preserving online services for activists for more than 20 years. 
 
-## About the test
+## RiseupVPN test
+
+The **RiseupVPN test** provides an automated way of examining whether RiseupVPN works in a tested network.
 
 This test evaluates if the bootstrap servers used during the self-configuration of the VPN clients can be reached. The test also checks if RiseupVPN's gateways can be reached on different ports and transports.
 
-In the future this test can form the base to offer a generic way to probe the reachability of other LEAP powered VPN infrastructure, self-hosted by other providers.
+In the future, this test can form the base to offer a generic way to probe the reachability of other LEAP-powered VPN infrastructure, self-hosted by other providers.
 
-For more details read the **[RiseupVPN test specification](https://github.com/ooni/spec/blob/master/nettests/ts-026-riseupvpn.md)**.
+For more details, read the **[RiseupVPN test specification](https://github.com/ooni/spec/blob/master/nettests/ts-026-riseupvpn.md)**.

--- a/content/nettest/riseupvpn.md
+++ b/content/nettest/riseupvpn.md
@@ -12,7 +12,7 @@ groups: ["proxies"]
 
 ## RiseupVPN test
 
-The **RiseupVPN test** provides an automated way of examining whether RiseupVPN works in a tested network.
+The **RiseupVPN test**, contributed by the [LEAP collective](https://leap.se/), provides an automated way of examining whether RiseupVPN works in a tested network.
 
 This test evaluates if the bootstrap servers used during the self-configuration of the VPN clients can be reached. The test also checks if RiseupVPN's gateways can be reached on different ports and transports.
 

--- a/content/nettest/riseupvpn.md
+++ b/content/nettest/riseupvpn.md
@@ -1,0 +1,23 @@
+---
+title: "Riseupvpn"
+short_description: "This test provides an automated way of examining whether RiseupVPN works in a
+tested network."
+groups: ["proxies"]
+---
+
+# RiseupVPN
+
+This test provides an automated way of examining whether RiseupVPN works in a tested network.
+
+
+## About RiseupVPN
+[RiseupVPN](https://riseup.net/vpn) is a non-commercial, donation-based VPN service. It offers simple to use clients to secure your internet traffic against survaillance and to circumvent internet censorship. RiseupVPN doesn't log any user data and doesn't require a registration.
+The software is based on [LEAP VPN](https://leap.se/), an open source VPN solution and is run by the [Riseup collective](https://riseup.net/about-us) which offers privacy preserving online services for activists since decades. 
+
+## About the test
+
+This test evaluates if the bootstrap server used during the self-configuration of the VPN clients can be reached. The test also checks the reachability of RiseupVPN's gateways on different ports and transports.
+
+For the future we aim to use this test as a blueprint to offer a generic way to test the reachability of LEAP instances deployed by other providers and users who self-host their VPN.
+
+For more details read the **[RiseupVPN test specification](https://github.com/ooni/spec/blob/master/nettests/ts-026-riseupvpn.md)**.

--- a/content/nettest/riseupvpn.md
+++ b/content/nettest/riseupvpn.md
@@ -12,14 +12,12 @@ This test provides an automated way of examining whether RiseupVPN works in a te
 
 ## About RiseupVPN
 [RiseupVPN](https://riseup.net/vpn) is a non-commercial, donation-based VPN service. It offers simple to use clients to secure your internet traffic against survaillance and to circumvent internet censorship. RiseupVPN doesn't log any user data and doesn't require registration.
-The software is based on [LEAP VPN](https://leap.se/), an open source VPN solution, and is run by the [Riseup collective](https://riseup.net/about-us) which offers privacy preserving online services for activists since more than 20 years. 
+The software is based on [LEAP VPN](https://leap.se/), an open source VPN solution, and is run by the [Riseup collective](https://riseup.net/about-us) which offers privacy preserving online services for activists for more than 20 years. 
 
 ## About the test
 
 This test evaluates if the bootstrap servers used during the self-configuration of the VPN clients can be reached. The test also checks if RiseupVPN's gateways can be reached on different ports and transports.
 
-For the future we aim to use this test as a blueprint to offer a generic way to test the reachability of LEAP instances deployed by other providers and users who self-host their VPN.
-Other providers, who self-host their LEAP powered VPN infrastructure, can use this test as a blueprint for probing its own reachability.
 In the future this test can form the base to offer a generic way to probe the reachability of other LEAP powered VPN infrastructure, self-hosted by other providers.
 
 For more details read the **[RiseupVPN test specification](https://github.com/ooni/spec/blob/master/nettests/ts-026-riseupvpn.md)**.


### PR DESCRIPTION
https://github.com/ooni/probe-android/pull/393 is kind of depending on this PR, since it includes some strings containing a link to the test description. The link is shown in the GUI in the test detail activity to provide additional information. 