### PR TITLE
make nonexisting image path break with informative message

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,5 +1,9 @@
 {{ $img := $.Page.Resources.GetMatch (.Get "src")}}
 
+{{ if eq $img nil }}
+{{ errorf "Cannot load image (check spelling?): <%s%s>" ($.Page.RelPermalink) (.Get "src") }}
+{{ else }}
+
 {{ $img600 := $img.Fit "1000x800" }}
 {{ $img1200 := $img.Fit "2000x1600" }}
 
@@ -18,3 +22,4 @@
   <span style="display: inline-block;font-style: italic;padding-bottom: 20px">{{ . }}</span>
   {{ end }}
 </div>
+{{ end }}


### PR DESCRIPTION
the error message for builds is quite cryptic, since it will complain that Fit cannot be found in a resource (because it's null if the GetMatch function fails).

this will leave a FIXME in the rendered output, which imho is more informative that the previous state.

edit: changed to log a fatal error.
