### PR TITLE
Update third parties section of OONI Data Policy

### DIFF
--- a/content/about/data-policy.md
+++ b/content/about/data-policy.md
@@ -4,9 +4,9 @@ description: This Data Policy discloses and explains what data the OONI project 
 aliases: ["/data-policy"]
 ---
 
-**Last modified:** July 28, 2022
+**Last modified:** September 6, 2022
 
-**Version:** 1.4.5
+**Version:** 1.4.6
 
 This Data Policy discloses and explains what data the [Open Observatory of
 Network Interference (OONI) project](https://ooni.org/) ("we", "us", or "our")
@@ -349,6 +349,11 @@ The performance tests included in the OONI Probe apps are conducted against thir
 provided by [Measurement Lab (M-Lab)](https://www.measurementlab.net/). M-Lab's
 services require the retention and disclosure of IP addresses for research
 purposes. Learn more about M-Lab's data governance through its [privacy statement](https://www.measurementlab.net/privacy/).
+
+As mentioned in the previous sections, we also use third-parties services to optimise our work:
+
+* We use the open source [Matomo analytics platform](https://matomo.org/) to analyse the users’ activity on our website. This platform **does not use cookies** and we **do not track any personal data**. We host this platform ourselves and do not collect any personal data to avoid any privacy-related risks for our users.
+* On OONI Explorer, we also use [Sentry](https://sentry.io/) to log crash reports, which helps us improve the service. These reports include only the information about your device which we need to address the crash reports. Please check [Sentry Privacy Policy](https://sentry.io/privacy/) for more details. If you are not sure you want to share any information with it, please opt-out of sharing crash reports with us in the settings of your application. 
 
 ## OONI web services
 


### PR DESCRIPTION
- Updated the date
- Updated the Data Policy version
- Added text: 
As mentioned in the previous sections, we also use third-parties services to optimise our work:

* We use the open source [Matomo analytics platform](https://matomo.org/) to analyse the users’ activity on our website. This platform **does not use cookies** and we **do not track any personal data**. We host this platform ourselves and do not collect any personal data to avoid any privacy-related risks for our users.
* On OONI Explorer, we also use [Sentry](https://sentry.io/) to log crash reports, which helps us improve the service. These reports include only the information about your device which we need to address the crash reports. Please check [Sentry Privacy Policy](https://sentry.io/privacy/) for more details. If you are not sure you want to share any information with it, please opt-out of sharing crash reports with us in the settings of your application.

- [ ] make sure that outreach happens
- [ ] when merging, double check that the publication date is today
