### PR TITLE
Linked to new test list docs via Get Involved section

### DIFF
--- a/layouts/section/get-involved.html
+++ b/layouts/section/get-involved.html
@@ -9,7 +9,7 @@
             <a href="https://lists.torproject.org/cgi-bin/mailman/listinfo/ooni-talk">ooni-talk</a> mailing list
             to receive updates and discuss all things related to the OONI-verse.
           </p>
-          <p><a href="https://www.transifex.com/otf/ooniprobe/">Translate the OONI Probe apps</a> and <a href="/documents/Getting started with OONI Probe.pdf">engage your communities</a> with censorship measurement research. 
+          <p>Translate the <a href="https://www.transifex.com/otf/ooniprobe/">OONI Probe apps</a> and <a href="https://www.transifex.com/otf/ooni-explorer/">OONI Explorer</a> to help bring censorship measurement research to communities worldwide.
           </p>  
           <p>Host an OONI workshop (<a href="https://docs.google.com/presentation/d/1Fb7xx1lRgqqEY3SA21_AytrzIeQy4rW-a0ecVsGtZ9A/edit?usp=sharing">slides</a>)!
           </p>
@@ -32,7 +32,7 @@
       <div class="col-12 col-sm-4">
         <h2>Test lists</h2>
         <p>Help us detect website censorship around the world! Learn all about
-        <a href="/get-involved/contribute-test-lists">test lists</a>, and contribute websites for censorship testing through our <a href="https://test-lists.ooni.org/">Test Lists Editor</a>.</p>
+        <a href="/get-involved/contribute-test-lists">test lists</a>, and contribute websites for censorship testing through our <a href="https://test-lists.ooni.org/">Test Lists Editor</a> (<a href="https://ooni.org/support/test-lists-editor">guide</a>) or by opening a pull request on <a href="https://ooni.org/support/github-test-lists">GitHub</a>.</p>
       </div>
 
       <div class="col-12 col-sm-4">


### PR DESCRIPTION
This PR adds links to the following via the Test Lists section of the Get Involved (https://ooni.org/get-involved) page:

* User Guide: Test Lists Editor, https://ooni.org/support/test-lists-editor
* GitHub guide for test lists, https://ooni.org/support/github-test-lists

I've also edited the Community section of the page to link to the OONI Explorer repo on Transifex (https://explore.transifex.com/otf/ooni-explorer/).