### PR TITLE
Expire the getJSON cache

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,11 @@ notAlternative = true
 [outputs]
   home = ["HTML", "PageIndex", "RSS"]
 
+[caches]
+[caches.getjson]
+dir = ":cacheDir/:project"
+maxAge = "10s"
+
 [markup]
   [markup.tableOfContents]
     endLevel = 5


### PR DESCRIPTION
Otherwise the netlify cache for getJSON will live indeifintly and the probe-desktop version will never get bumped
