### PR TITLE
Drop matomo tracking and update privacy policy

### DIFF
--- a/content/about/data-policy.md
+++ b/content/about/data-policy.md
@@ -4,9 +4,9 @@ description: This Data Policy discloses and explains what data the OONI project 
 aliases: ["/data-policy"]
 ---
 
-**Last modified:** March 20, 2023
+**Last modified:** February 23, 2024
 
-**Version:** 1.4.7
+**Version:** 1.5.0
 
 This Data Policy discloses and explains what data the [Open Observatory of
 Network Interference (OONI) project](https://ooni.org/) ("we", "us", or "our")
@@ -154,18 +154,15 @@ Details about our specific setup can be found in [ooni/sysadmin](https://github.
 
 ### OONI website
 
-We use the open source [Matomo](https://matomo.org/) analytics platform (which we host ourselves) to
+We use the open source [Umami](https://umami.is/) analytics platform (using the [EU umami cloud service](https://umami.is/docs/cloud)) to
 collect data on how many visits [OONI Explorer](https://explorer.ooni.org/) and our [website](https://ooni.org/) receive. This is
 done **without the use of cookies**. Since we do not use cookies or track any
-personal data, these analytics are [enabled by default](https://matomo.org/cookie-consent-banners/). 
+personal data, these analytics are [enabled by default](https://umami.is/docs/faq).
 
 We do not record the full IP address of users (which is “anonymised” to the
 first 3 octets, ex. 123.45.67.0).
 
 On [OONI Explorer](https://explorer.ooni.org/), we also use [Sentry](https://sentry.io/) to log crash reports, which helps us improve the service.
-
-You can opt out of our use of analytics on [OONI Explorer](https://explorer.ooni.org/) and the [OONI website](https://ooni.org/)
-by **unchecking the opt-out box** at the end of this Data Policy.
 
 We will notify you of any future changes to our use of analytics through an
 update to this Data Policy.
@@ -364,11 +361,16 @@ purposes. Learn more about M-Lab's data governance through their [privacy statem
 
 **Sentry**
 
-We use [Sentry](https://sentry.io/privacy/) to log crash reports for the [OONI Probe](https://ooni.org/install) apps. This information is essential for identifying bugs and improving the performance of the apps. You can opt out through the settings of the OONI Probe apps. 
+We use [Sentry](https://sentry.io/privacy/) to log crash reports for the [OONI Probe](https://ooni.org/install) apps. This information is essential for identifying bugs and improving the performance of the apps. You can opt out through the settings of the OONI Probe apps.
 
-We also use [Sentry](https://sentry.io/privacy/) to log crash reports on [OONI Explorer](https://explorer.ooni.org/), which helps us improve the performance of the service. You can opt out of our use of analytics on OONI Explorer by unchecking the opt-out box at the end of this Data Policy.
+We also use [Sentry](https://sentry.io/privacy/) to log crash reports on [OONI Explorer](https://explorer.ooni.org/), which helps us improve the performance of the service.
 
 As part of crash reports, we collect sanitized technical data, but we do *not* collect the IP address or a unique identifier of the user. Given that Sentry is a third-party service, we recommend referring to their [privacy policy](https://sentry.io/privacy/).
+
+**Umami Cloud**
+
+We use [umami cloud](https://umami.is/docs/cloud) for collecting privacy
+preserving analytics about website visits, specifically on the EU instance.
 
 ## OONI web services
 
@@ -395,5 +397,3 @@ Key ID:
 Fingerprint:
 4C15 DDA9 96C6 C0CF 48BD 3309 6B29 43F0 0CB1 77B7
 ```
-
-{{< tracking-opt-out >}}

--- a/content/about/data-policy.md
+++ b/content/about/data-policy.md
@@ -154,7 +154,7 @@ Details about our specific setup can be found in [ooni/sysadmin](https://github.
 
 ### OONI website
 
-We use the open source [Umami](https://umami.is/) analytics platform (using the [EU umami cloud service](https://umami.is/docs/cloud)) to
+We use the open source [Umami](https://umami.is/) analytics platform (using the [EU Umami cloud service](https://umami.is/docs/cloud)) to
 collect data on how many visits [OONI Explorer](https://explorer.ooni.org/) and our [website](https://ooni.org/) receive. This is
 done **without the use of cookies**. Since we do not use cookies or track any
 personal data, these analytics are [enabled by default](https://umami.is/docs/faq).
@@ -369,7 +369,7 @@ As part of crash reports, we collect sanitized technical data, but we do *not* c
 
 **Umami Cloud**
 
-We use [umami cloud](https://umami.is/docs/cloud) for collecting privacy
+We use [Umami Cloud](https://umami.is/docs/cloud) for collecting privacy
 preserving analytics about website visits, specifically on the EU instance.
 
 ## OONI web services

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,24 +23,10 @@
 
   <link rel="icon" type="image/png" href="/images/favicon.png" />
   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ooni-run/dist/widgets.js" defer></script>
-  
-  <!-- Matomo -->
-  <script type="text/javascript">
-                      var _paq = window._paq || [];
-                      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-                      _paq.push(['disableCookies']);
-                      _paq.push(['trackPageView']);
-                      _paq.push(['enableLinkTracking']);
-                      (function () {
-                        var u = "//matomo.ooni.org/";
-                        _paq.push(['setTrackerUrl', u + 'matomo.php']);
-                        _paq.push(['setSiteId', '1']);
-                      var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-                      g.type = 'text/javascript'; g.async = true; g.defer = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
-                    })();
-  </script>
+
+  <!-- Umami Cloud EU-->
   <script defer src="https://eu.umami.is/script.js" data-website-id="6c8fa418-795c-41cc-9840-40c43a88648a" domains="ooni.org,ooni.github.io,ooni.netlify.com,openobservatory.github.io"></script>
-  <!-- End Matomo Code -->
+  <!-- End Umami Code -->
 </head>
 <body>
 

--- a/layouts/shortcodes/tracking-opt-out.html
+++ b/layouts/shortcodes/tracking-opt-out.html
@@ -1,4 +1,0 @@
-<iframe
-        style="border: 0; height: 200px; width: 600px;"
-        src="https://matomo.ooni.org/index.php?module=CoreAdminHome&action=optOut&language=en&backgroundColor=ffffff&fontColor=000000&fontSize=&fontFamily=Fira%20sans"
-        ></iframe>


### PR DESCRIPTION
This PR edits the OONI Data Policy, reflecting that we are replacing the use of [Matomo](https://matomo.org/) with [Umami](https://umami.is/) analytics.
