### PR TITLE
Replace deprecated apt-key with proper keyring in ubuntu/debian installation guide

### DIFF
--- a/content/install/cli/ubuntu-debian.md
+++ b/content/install/cli/ubuntu-debian.md
@@ -7,7 +7,7 @@ platform: cli
 1) Install the GPG key:
 
 ```
-sudo apt-key adv --verbose --keyserver hkp://keyserver.ubuntu.com --recv-keys 'B5A08F01796E7F521861B449372D1FF271F2DD50'
+sudo gpg --no-default-keyring --keyserver hkp://keyserver.ubuntu.com --keyring /etc/apt/keyrings/ooni-apt-keyring.gpg --recv-keys 'B5A08F01796E7F521861B449372D1FF271F2DD50'
 ```
 
 You can choose how to fetch OONI Probe:
@@ -15,14 +15,14 @@ You can choose how to fetch OONI Probe:
 2.A) Using HTTP. This is the recommended option.
 
 ```
-echo "deb http://deb.ooni.org/ unstable main" | sudo tee /etc/apt/sources.list.d/ooniprobe.list
+echo "deb [signed-by=/etc/apt/keyrings/ooni-apt-keyring.gpg] https://deb.ooni.org/ unstable main" | sudo tee /etc/apt/sources.list.d/ooniprobe.list
 ```
 
 2.B) Using Tor. This is an alternative option in case the HTTP repository is not reachable. This requires running the tor daemon on your system.
 
 ```
 sudo apt-get install tor apt-transport-tor
-echo "deb tor+http://deb.ooni.org/ unstable main" | sudo tee /etc/apt/sources.list.d/ooniprobe.list
+echo "deb [signed-by=/etc/apt/keyrings/ooni-apt-keyring.gpg] tor+http://deb.ooni.org/ unstable main" | sudo tee /etc/apt/sources.list.d/ooniprobe.list
 ```
 
 3) Finally, update the package list and install OONI Probe


### PR DESCRIPTION
The deprecation warning annoyed me for a while now, and this is what seems to be the solution.