### PR TITLE
Updated OONI Data Policy for launch of OONI Run v2

### DIFF
--- a/content/about/data-policy.md
+++ b/content/about/data-policy.md
@@ -4,7 +4,7 @@ description: This Data Policy discloses and explains what data the OONI project 
 aliases: ["/data-policy"]
 ---
 
-**Last modified:** February 23, 2024
+**Last modified:** October 15, 2024
 
 **Version:** 1.6.0
 

--- a/content/about/data-policy.md
+++ b/content/about/data-policy.md
@@ -171,7 +171,7 @@ update to this Data Policy.
 
 ### Data We Collect
 
-If you create an [OONI Run](https://run.ooni.org/) v2 link, we will collect the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help reduce the risk of running malicious links. We do *not* collect your email address when you log into the [OONI Run](https://run.ooni.org/) platform, but only when you create an OONI Run link.
+Logging into the [OONI Run](https://run.ooni.org/) platform is facilitated by a one-time magic link. We do *not* store your email address upon login. Your email address is saved as part of the description in any OONI Run link you create and is displayed to end users of your links. We collect and display your email address in the OONI Run links you create to enable OONI Probe users who receive your OONI Run link to trust it and to have the opportunity to reach out to you (for example, if they would like to propose more URLs for testing). Our goal is to help facilitate more trust and coordination among testers.
 
 We collect different types of network measurements when you run different types
 of OONI Probe tests. You can learn how each OONI Probe test works (and what
@@ -338,7 +338,7 @@ Data required for sending out push notifications will be stored separately on a
 secure database server operated by OONI (which is different from the public
 metadb that hosts OONI Probe measurements).
 
-If you create an [OONI Run](https://run.ooni.org/) v2 link, we will store the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help reduce the risk of running malicious links.
+If you create an [OONI Run](https://run.ooni.org/) v2 link, we will store the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help facilitate more trust and coordination among testers.
 
 We do *not* store your email address when you log into the [OONI Run](https://run.ooni.org/) platform, but only when you create an OONI Run link.
 

--- a/content/about/data-policy.md
+++ b/content/about/data-policy.md
@@ -171,7 +171,7 @@ update to this Data Policy.
 
 ### Data We Collect
 
-If you create an [OONI Run](https://run.ooni.io/) v2 link, we will collect the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help reduce the risk of running malicious links. We do *not* collect your email address when you log into the [OONI Run](https://run.ooni.io/) platform, but only when you create an OONI Run link.
+If you create an [OONI Run](https://run.ooni.org/) v2 link, we will collect the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help reduce the risk of running malicious links. We do *not* collect your email address when you log into the [OONI Run](https://run.ooni.org/) platform, but only when you create an OONI Run link.
 
 We collect different types of network measurements when you run different types
 of OONI Probe tests. You can learn how each OONI Probe test works (and what
@@ -338,9 +338,9 @@ Data required for sending out push notifications will be stored separately on a
 secure database server operated by OONI (which is different from the public
 metadb that hosts OONI Probe measurements).
 
-If you create an [OONI Run](https://run.ooni.io/) v2 link, we will store the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help reduce the risk of running malicious links.
+If you create an [OONI Run](https://run.ooni.org/) v2 link, we will store the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help reduce the risk of running malicious links.
 
-We do *not* store your email address when you log into the [OONI Run](https://run.ooni.io/) platform, but only when you create an OONI Run link.
+We do *not* store your email address when you log into the [OONI Run](https://run.ooni.org/) platform, but only when you create an OONI Run link.
 
 ### Data We Publish
 
@@ -356,7 +356,7 @@ For more information on the license under which the data is released, see
 
 We will *not* publish data related to analytics and push notification support, both of which are securely stored separately from the public measurement metadb. 
 
-The email address that you use to create an [OONI Run](https://run.ooni.io/) v2 link will be published in the link that you create. This enables OONI Probe users who receive your OONI Run link to trust it.
+The email address that you use to create an [OONI Run](https://run.ooni.org/) v2 link will be published in the link that you create. This enables OONI Probe users who receive your OONI Run link to trust it.
 
 ### Third-party services
 

--- a/content/about/data-policy.md
+++ b/content/about/data-policy.md
@@ -6,7 +6,7 @@ aliases: ["/data-policy"]
 
 **Last modified:** February 23, 2024
 
-**Version:** 1.5.0
+**Version:** 1.6.0
 
 This Data Policy discloses and explains what data the [Open Observatory of
 Network Interference (OONI) project](https://ooni.org/) ("we", "us", or "our")
@@ -170,6 +170,8 @@ update to this Data Policy.
 ## OONI Probe
 
 ### Data We Collect
+
+If you create an [OONI Run](https://run.ooni.io/) v2 link, we will collect the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help reduce the risk of running malicious links. We do *not* collect your email address when you log into the [OONI Run](https://run.ooni.io/) platform, but only when you create an OONI Run link.
 
 We collect different types of network measurements when you run different types
 of OONI Probe tests. You can learn how each OONI Probe test works (and what
@@ -336,6 +338,10 @@ Data required for sending out push notifications will be stored separately on a
 secure database server operated by OONI (which is different from the public
 metadb that hosts OONI Probe measurements).
 
+If you create an [OONI Run](https://run.ooni.io/) v2 link, we will store the email address that you use for the creation of that link. This enables OONI Probe users who receive your OONI Run link to trust it based on your email address (which is displayed in the OONI Run link you create). This can help reduce the risk of running malicious links.
+
+We do *not* store your email address when you log into the [OONI Run](https://run.ooni.io/) platform, but only when you create an OONI Run link.
+
 ### Data We Publish
 
 We [publish](https://ooni.org/data/) ALL of the OONI Probe network measurement data that we have collected
@@ -348,7 +354,9 @@ web interface, called [OONI Explorer](https://explorer.ooni.org/).
 For more information on the license under which the data is released, see
 [github.com/ooni/license/data](https://github.com/ooni/license/tree/master/data).
 
-We will *not* publish data related to analytics and push notification support, both of which are securely stored separately from the public measurement metadb.
+We will *not* publish data related to analytics and push notification support, both of which are securely stored separately from the public measurement metadb. 
+
+The email address that you use to create an [OONI Run](https://run.ooni.io/) v2 link will be published in the link that you create. This enables OONI Probe users who receive your OONI Run link to trust it.
 
 ### Third-party services
 


### PR DESCRIPTION
As part of this PR, I have updated the OONI Data Policy to account for changes introduced with OONI Run v2.

We need to **update the date** of the Data Policy based on the launch date of OONI Run v2.

I have already updated the version number of the Data Policy, and that does not need to change. 
