### PR TITLE
WIP Adds support for Sveltia CMS 

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -6,9 +6,6 @@ pluralizeListTitles = false
 timeout = 120000
 publishDir = "public/"
 
-[params]
-description = "The Open Observatory of Network Interference (OONI) is a global community measuring internet censorship around the world. Run OONI Probe to detect internet censorship. Use OONI Explorer to track internet censorship worldwide in near real-time."
-
 [Languages]
 [Languages.ar]
 [Languages.ca]
@@ -26,6 +23,9 @@ description = "The Open Observatory of Network Interference (OONI) is a global c
 [Languages.my]
 [Languages.kk]
 
+[[module.imports]]
+  path = "github.com/privatemaker/headless-cms"
+
 [outputFormats]
 [outputFormats.PageIndex]
 mediaType = "application/json"
@@ -34,7 +34,7 @@ isPlainText = true
 notAlternative = true
 
 [outputs]
-  home = ["HTML", "PageIndex", "RSS"]
+  home = ["HTML", "PageIndex", "RSS", "HeadlessCMSConfig" ]
 
 [caches]
 [caches.getjson]

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -1,0 +1,8 @@
+description: "The Open Observatory of Network Interference (OONI) is a global community measuring internet censorship around the world. Run OONI Probe to detect internet censorship. Use OONI Explorer to track internet censorship worldwide in near real-time."
+
+headless_cms:
+  engine: "sveltia"
+  site_url: "https://ooni.org"
+  backend:
+  name: "github"
+  repo: "ooni/ooni.org"

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -4,5 +4,72 @@ headless_cms:
   engine: "sveltia"
   site_url: "https://ooni.org"
   backend:
-  name: "github"
-  repo: "ooni/ooni.org"
+    name: "github"
+    repo: "ooni/ooni.org"
+  commit_messages:
+    create: "Create {{slug}} ({{collection}})"
+    update: "Update {{slug}} ({{collection}})" 
+    delete: "Delete {{slug}} ({{collection}})" 
+    uploadMedia: "Upload - {{path}}"
+    deleteMedia: "Delete - {{path}}"
+    openAuthoring: '{{message}}'
+  publish_mode: "simple"
+  media_folder: "static/images/uploads"
+  public_folder: "/images/uploads"
+  locale: "en"
+  slug:
+    encoding: "ascii"
+    clean_accents: true
+    sanitize_replacement: "-"
+  collections:
+    - name: "blog"
+      label: "Blog Posts"
+      label_singular: "Blog Post"
+      folder: "content/post"
+      path: "{{slug}}/index"
+      media_folder: "images"
+      public_folder: ""
+      create: true
+      delete: false
+      widget: "list"
+      preview_path: "post/{{slug}}"
+      editor:
+        preview: true
+      fields:
+        - label: "Title"
+          name: "title"
+          widget: "string"
+        - lable: "Draft"
+          name: "draft"
+          widget: "boolean"
+        - label: "Description"
+          name: "description"
+          widget: "string"
+        - label: "Author"
+          name: "author"
+          widget: "string"
+        - label: "Publish Date"
+          name: "date"
+          widget: "datetime"
+          format: "ll"
+        - label: "Image"
+          name: "thumbnail"
+          widget: "image"
+          choose_url: true
+          media_library:
+            config:
+              multiple: true
+        - label: "Body"
+          name: "body"
+          widget: "markdown"
+        - label: "Tags"
+          name: "tags"
+          widget: "list"
+          allow_add: true
+        - label: "Categories"
+          name: "categories"
+          widget: "select"
+          default: "report"
+          options:
+            - { value: "report", label: "Report" }
+            - { value: "blog", label: "Blog" }

--- a/content/admin/_index.md
+++ b/content/admin/_index.md
@@ -1,0 +1,4 @@
+---
+title: OONI Website CMS
+layout: headless-cms
+---

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/ooni/ooni.org
+
+go 1.21.1
+
+require github.com/privatemaker/headless-cms v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/privatemaker/headless-cms v0.1.1 h1:pYDKvV8ZmgrAaH5WTtKP1TrwpIXSj3t9u72sTfCxDWE=
+github.com/privatemaker/headless-cms v0.1.1/go.mod h1:ZcHkPZzL9yCsBdmn9FpoIW35snTyj1bDOfqT0ZFJoZE=


### PR DESCRIPTION
This pull-request adds support for [Sveltia CMS](https://github.com/sveltia/sveltia-cms) which is a "headless cms" that generates a GUI content editor which allows non-technical users to edit website content without ever needing to learn markdown or YAML front-matter.

You can test the CMS editor locally from building this repo from my branch. Then load

- http://localhost:1313/admin

If you use Chrome browser you can then select `Work with Local Repository`

![Screenshot 2025-02-03 at 20-45-34 OONI Website CMS](https://github.com/user-attachments/assets/3c6e5c3a-367a-4728-9708-8619a7e00fa4)

I flagged this as WIP as there are few steps which need to happen before it will work properly in production.

- [ ] Setup authentication gateway
- [ ] Test editing of content

Information about this is in [Decap Docs: Github Backend](https://decapcms.org/docs/github-backend/)